### PR TITLE
Fix parsing for continuous date lines

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -2,7 +2,10 @@ function parseMultiFormatData() {
   const inputSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("シート1");
   const outputSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("抽出結果") || SpreadsheetApp.getActiveSpreadsheet().insertSheet("抽出結果");
 
-  const rawText = inputSheet.getRange("A1").getValue();
+  let rawText = inputSheet.getRange("A1").getValue();
+  // 改行がない連続データでも各明細を抽出できるよう、日付付き明細パターン毎に改行を補完
+  const dateBlock = /(\d{4}\/\d{2}\/\d{2}\s+[^¥]+?\s+¥[\d,]+\s+\d+\s+¥[\d,]+)/g;
+  rawText = rawText.replace(dateBlock, '$1\n');
   const lines = rawText.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
 
   let date = "", client = "", project = "", itemText = "";


### PR DESCRIPTION
## Summary
- handle input that has no newline separation by inserting line breaks between date blocks

## Testing
- `node - <<'NODE'
function parse(text){
  text = text.replace(/(\d{4}\/\d{2}\/\d{2}\s+[^¥]+?\s+¥[\d,]+\s+\d+\s+¥[\d,]+)/g, '$1\n');
  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
  return lines;
}
console.log(parse('2025/05/31 KINS クレンジングオイル ¥6,000 4 ¥24,000 2025/05/31 トリプルPDRNクリーム TTO ¥6,000 8 ¥48,000')); 
NODE

------
https://chatgpt.com/codex/tasks/task_e_6883221d200c8328b47498faf2122e1f