### PR TITLE
Implement formula totals in output sheet

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -43,16 +43,17 @@ function parseMultiFormatData() {
       const name = m[1].trim();
       const qty = parseInt(m[3].replace(/,/g, ''));
       const price = parseFloat(m[4]);
-      const total = parseInt(m[2].replace(/,/g, ''));
-      output.push(["", "", "", name, price, qty, total]);
+      output.push(["", "", "", name, price, qty, price * qty]);
       continue;
     }
 
     // パターン③：日付付き明細
     m = line.match(/^(\d{4}\/\d{2}\/\d{2})\s+(.+?)\s+¥([\d,]+)\s+(\d+)\s+¥([\d,]+)/);
     if (m) {
-      const [_, dt, name, unit, qty, total] = m;
-      output.push([dt, "", "", name.trim(), parseInt(unit.replace(/,/g, '')), parseInt(qty), parseInt(total.replace(/,/g, ''))]);
+      const [_, dt, name, unit, qty] = m;
+      const price = parseInt(unit.replace(/,/g, ''));
+      const quantity = parseInt(qty);
+      output.push([dt, "", "", name.trim(), price, quantity, price * quantity]);
       continue;
     }
 
@@ -75,6 +76,15 @@ function parseMultiFormatData() {
   if (output.length > 0) {
     outputSheet.getRange(1, 1, 1, 7).setValues([["日付", "広告主", "案件名", "商品名", "単価", "件数", "金額"]]);
     outputSheet.getRange(2, 1, output.length, 7).setValues(output);
+
+    const formulas = [];
+    for (let i = 0; i < output.length; i++) {
+      formulas.push([`=E${i + 2}*F${i + 2}`]);
+    }
+    outputSheet.getRange(2, 7, output.length, 1).setFormulas(formulas);
+
+    const sumRow = output.length + 2;
+    outputSheet.getRange(sumRow, 7).setFormula(`=SUM(G2:G${sumRow - 1})`);
   } else {
     outputSheet.getRange("A1").setValue("抽出データが見つかりませんでした。");
   }


### PR DESCRIPTION
## Summary
- parse totals dynamically from unit price and quantity
- add formulas to compute totals per row
- append SUM of totals at the end of column G

## Testing
- `node -e "require('./parseMultiFormatData')"`


------
https://chatgpt.com/codex/tasks/task_e_6883341e036c8328aea57a2f5c31d089