### PR TITLE
Fix yen sign parsing in apps script

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -3,6 +3,8 @@ function parseMultiFormatData() {
   const outputSheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName("抽出結果") || SpreadsheetApp.getActiveSpreadsheet().insertSheet("抽出結果");
 
   let rawText = inputSheet.getRange("A1").getValue();
+  // Normalize different yen symbols to a standard form so regex patterns match
+  rawText = rawText.replace(/[\\￥]/g, '¥');
   // 改行がない連続データでも各明細を抽出できるよう、日付付き明細パターン毎に改行を補完
   const dateBlock = /(\d{4}\/\d{2}\/\d{2}\s+[^¥]+?\s+¥[\d,]+\s+\d+\s+¥[\d,]+)/g;
   rawText = rawText.replace(dateBlock, '$1\n');


### PR DESCRIPTION
## Summary
- handle `\` and `￥` characters by normalizing them to the standard `¥` symbol before running regexes

## Testing
- `node - <<'EOF'
function parseSingleLine(line){
  line=line.replace(/[\\￥]/g,'¥');
  const qtyRegex=/(.+?)\s+¥([\d,]+)\s*\((\d+)\)\s+¥([\d,]+)/g;
  const match=qtyRegex.exec(line);
  if(match){
    return {name:match[1],unit:parseInt(match[2].replace(/,/g,'')),qty:parseInt(match[3]),amount:parseInt(match[4].replace(/,/g,''))};
  }
  return null;
}
const sample="SBI証券（一般媒体） \uFFE55,060 (1) \uFFE55,060";
console.log(parseSingleLine(sample));
EOF

------
https://chatgpt.com/codex/tasks/task_e_6883382d4d9c8328bfa7dc9c081eaa3f