### PR TITLE
Fix unit price grouping

### DIFF
--- a/summarizeAds.gs
+++ b/summarizeAds.gs
@@ -104,7 +104,10 @@ function summarizeAdsFromFolder() {
         if (!ad) {
           continue;
         }
-        var unit = parseFloat(String(row[5]).replace(/,/g, '')) || 0;
+        var rawUnit = row[5];
+        var unit = typeof rawUnit === 'number'
+          ? rawUnit
+          : parseFloat(String(rawUnit).replace(/[¥￥,円]/g, '').trim()) || 0;
         var key = ad + '\u0000' + unit;
         if (!adPriceMap[key]) {
           adPriceMap[key] = { ad: ad, unit: unit, count: 0 };


### PR DESCRIPTION
## Summary
- normalize yen symbols when parsing unit price so ads with different prices appear as separate rows

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68871abadeb08328b7ed75f52023590d