### PR TITLE
Add dynamic ad column detection

### DIFF
--- a/summarizeAds.gs
+++ b/summarizeAds.gs
@@ -97,14 +97,33 @@ function summarizeAdsFromFolder() {
         continue;
       }
 
+      // Determine the column positions dynamically based on the header row
+      var header = data[0];
+      var adCol = header.indexOf('広告');
+      if (adCol === -1) {
+        Logger.log('広告 column not found in ' + file.getName());
+        file.setTrashed(true);
+        continue;
+      }
+      var unitCol;
+      if (adCol === 2) { // C column pattern
+        unitCol = 5;     // F column
+      } else if (adCol === 7) { // H column pattern
+        unitCol = 22;    // W column
+      } else {
+        Logger.log('Unexpected 広告 column position in ' + file.getName() + ': ' + adCol);
+        file.setTrashed(true);
+        continue;
+      }
+
       var adPriceMap = {};
       for (var i = 1; i < data.length; i++) {
         var row = data[i];
-        var ad = row[2];
+        var ad = row[adCol];
         if (!ad) {
           continue;
         }
-        var rawUnit = row[5];
+        var rawUnit = row[unitCol];
         var unit = typeof rawUnit === 'number'
           ? rawUnit
           : parseFloat(String(rawUnit).replace(/[¥￥,円]/g, '').trim()) || 0;


### PR DESCRIPTION
## Summary
- auto-detect the column containing `広告` in each input sheet
- when the header's `広告` is in column C use unit column F, if in column H use unit column W

## Testing
- `npm test` *(fails: cannot find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68872f743e8c8328950fa00def4901f2