### PR TITLE
Refactor sheet deletion to standalone script

### DIFF
--- a/deleteOtherSheets.gs
+++ b/deleteOtherSheets.gs
@@ -1,0 +1,11 @@
+function deleteOtherSheets(ss, keepNames) {
+  ss = ss || SpreadsheetApp.getActiveSpreadsheet();
+  keepNames = keepNames || [];
+  ss.getSheets().forEach(function(sheet) {
+    var name = sheet.getName();
+    if (keepNames.indexOf(name) === -1) {
+      ss.deleteSheet(sheet);
+    }
+  });
+}
+

--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -3,13 +3,8 @@ function parseMultiFormatData() {
   const inputSheet = ss.getSheetByName("シート1");
   const outputSheet = ss.getSheetByName("抽出結果") || ss.insertSheet("抽出結果");
 
-  // Remove every other sheet except シート1 and 抽出結果
-  ss.getSheets().forEach(sheet => {
-    const name = sheet.getName();
-    if (name !== "シート1" && name !== "抽出結果") {
-      ss.deleteSheet(sheet);
-    }
-  });
+  // Remove every sheet except シート1 and 抽出結果
+  deleteOtherSheets(ss, ["シート1", "抽出結果"]);
 
   let rawText = inputSheet.getRange("A1").getValue();
   // Normalize different yen symbols to a standard form so regex patterns match


### PR DESCRIPTION
## Summary
- move sheet cleanup logic from `parseMultiFormatData` to new `deleteOtherSheets.gs`
- call the new function from `parseMultiFormatData`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68883e9b9d048328bb5e08996e6e0427