### PR TITLE
Update sheet cleanup workflow

### DIFF
--- a/deleteOtherSheets.gs
+++ b/deleteOtherSheets.gs
@@ -9,3 +9,10 @@ function deleteOtherSheets(ss, keepNames) {
   });
 }
 
+// Standalone helper to remove sheets except the default ones.
+function cleanupSheets() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var keepNames = ['シート1', '抽出結果'];
+  deleteOtherSheets(ss, keepNames);
+}
+

--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -3,9 +3,6 @@ function parseMultiFormatData() {
   const inputSheet = ss.getSheetByName("シート1");
   const outputSheet = ss.getSheetByName("抽出結果") || ss.insertSheet("抽出結果");
 
-  // Remove every sheet except シート1 and 抽出結果
-  deleteOtherSheets(ss, ["シート1", "抽出結果"]);
-
   let rawText = inputSheet.getRange("A1").getValue();
   // Normalize different yen symbols to a standard form so regex patterns match
   rawText = rawText.replace(/[\\￥]/g, '¥');


### PR DESCRIPTION
## Summary
- remove sheet deletion logic from `parseMultiFormatData`
- add `cleanupSheets` helper to handle sheet deletion separately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888595e07ac8328ae14da82ea871cc0