### PR TITLE
Add DL sheet CSV download script

### DIFF
--- a/downloadCsvDl.gs
+++ b/downloadCsvDl.gs
@@ -1,0 +1,30 @@
+function downloadCsvDlShiftJis() {
+  var spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet = spreadsheet.getSheetByName('DL');
+  if (!sheet) {
+    SpreadsheetApp.getUi().alert('DL sheet not found.');
+    return;
+  }
+  var data = sheet.getDataRange().getValues();
+  var csvContent = '';
+  for (var i = 0; i < data.length; i++) {
+    var row = data[i];
+    for (var j = 0; j < row.length; j++) {
+      csvContent += row[j];
+      if (j < row.length - 1) {
+        csvContent += ',';
+      }
+    }
+    csvContent += '\n';
+  }
+  var blob = Utilities.newBlob(csvContent, 'text/csv', 'DL.csv').setContentTypeFromExtension();
+  var sjisBlob = convertToShiftJis(blob);
+  SpreadsheetApp.getUi().showModalDialog(HtmlService.createHtmlOutput('<a href="' + sjisBlob.getBlob().getDataUrl() + '" target="_blank">Download</a>'), 'Download DL CSV (Shift_JIS)');
+}
+
+function convertToShiftJis(blob) {
+  var uint8Array = new Uint8Array(blob.getBytes());
+  var sjisArray = Encoding.convert(uint8Array, {to: 'SJIS', from: 'UTF8'});
+  var sjisBlob = Utilities.newBlob(sjisArray, 'text/csv', blob.getName());
+  return sjisBlob;
+}


### PR DESCRIPTION
## Summary
- add `downloadCsvDlShiftJis` to export the "DL" sheet in Shift_JIS CSV format

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68886f1c68dc8328ba805701ac497bc0