### PR TITLE
Add helper functions for advertiser and promotion API

### DIFF
--- a/registerPromotionItem.gs
+++ b/registerPromotionItem.gs
@@ -1,0 +1,47 @@
+// Utility functions to interact with advertiser and promotion APIs
+// and to register a new promotion item. This demonstrates how to
+// combine existing working endpoints.
+
+const BASE_API_URL = 'https://otonari-asp.com/api/v1/m';
+
+function searchAdvertiserById(advId) {
+  const props = PropertiesService.getScriptProperties();
+  const accessKey = props.getProperty('API_ACCESS_KEY');
+  const secretKey = props.getProperty('API_SECRET_KEY');
+  const headers = { 'X-Auth-Token': accessKey + ':' + secretKey };
+  const url = `${BASE_API_URL}/advertiser/search?id=${encodeURIComponent(advId)}`;
+  const response = UrlFetchApp.fetch(url, { method: 'get', headers: headers });
+  return JSON.parse(response.getContentText());
+}
+
+function searchPromotionById(promoId) {
+  const props = PropertiesService.getScriptProperties();
+  const accessKey = props.getProperty('API_ACCESS_KEY');
+  const secretKey = props.getProperty('API_SECRET_KEY');
+  const headers = { 'X-Auth-Token': accessKey + ':' + secretKey };
+  const url = `${BASE_API_URL}/promotion/search?id=${encodeURIComponent(promoId)}`;
+  const response = UrlFetchApp.fetch(url, { method: 'get', headers: headers });
+  return JSON.parse(response.getContentText());
+}
+
+function registerPromotionItem(promotionId, itemName, itemUrl) {
+  const props = PropertiesService.getScriptProperties();
+  const accessKey = props.getProperty('API_ACCESS_KEY');
+  const secretKey = props.getProperty('API_SECRET_KEY');
+  const headers = {
+    'X-Auth-Token': accessKey + ':' + secretKey,
+    'Content-Type': 'application/json'
+  };
+  const payload = {
+    promotion: promotionId,
+    name: itemName,
+    url_type: ['via_system'],
+    url: itemUrl,
+    display_url: itemUrl
+  };
+  const response = UrlFetchApp.fetch(
+    `${BASE_API_URL}/promotion_item/regist`,
+    { method: 'post', headers: headers, payload: JSON.stringify(payload) }
+  );
+  return JSON.parse(response.getContentText());
+}


### PR DESCRIPTION
## Summary
- provide utility to search advertisers and promotions by id
- add helper to register new promotion items

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68889b4f0ac883288b12d3794fc847be