### PR TITLE
Fix property keys for API credentials

### DIFF
--- a/processSeikaChanges.gs
+++ b/processSeikaChanges.gs
@@ -113,9 +113,9 @@ function convertToShiftJis(blob) {
 // Fetch all results that occurred last month via the API.
 function fetchLastMonthResults() {
   var props = PropertiesService.getScriptProperties();
-  var baseUrl = props.getProperty('https://otonari-asp.com/api/v1/m');
-  var accessKey = props.getProperty('agqnoournapf');
-  var secretKey = props.getProperty('1kvu9dyv1alckgocc848socw');
+  var baseUrl = props.getProperty('API_BASE_URL');
+  var accessKey = props.getProperty('API_ACCESS_KEY');
+  var secretKey = props.getProperty('API_SECRET_KEY');
   if (!baseUrl || !accessKey || !secretKey) {
     SpreadsheetApp.getUi().alert('API credentials are not set.');
     return [];


### PR DESCRIPTION
## Summary
- use property keys `API_BASE_URL`, `API_ACCESS_KEY`, and `API_SECRET_KEY` in `processSeikaChanges.gs`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68898d9840b4832890de053fdbd58313