### PR TITLE
Extract numeric fields from invoice-style lines

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -39,8 +39,9 @@ function parseMultiFormatData() {
       Logger.log(`案件名を検出: ${project}`);
     }
     if (line.startsWith("内容")) {
-      itemText = lines[i + 1];
+      itemText = line.replace("内容", "").trim();
       Logger.log(`内容行を検出: ${itemText}`);
+      continue;
     }
 
     // パターン①：AF成果形式
@@ -97,15 +98,18 @@ function parseMultiFormatData() {
     if (qpMatched) continue;
 
     // パターン⑤：請求書風明細
-    m = line.match(/^¥([\d,]+)\s+(\d+)\s+¥([\d,]+)/);
+    m = line.match(/^¥([\d,]+)\s+([\d,]+)\s+¥([\d,]+)/);
     if (m && itemText) {
+      const unit = parseInt(m[1].replace(/,/g, ''), 10);
+      const qty = parseInt(m[2].replace(/,/g, ''), 10);
+      const amount = parseInt(m[3].replace(/,/g, ''), 10);
       const names = itemText.split("、").map(n => n.trim());
       for (let name of names) {
-        Logger.log(`請求書風明細を検出: 日付=${date}, 広告主=${client}, 案件名=${project}, 商品名=${name}`);
-        // 件数と単価は手入力とするため空欄を出力
-        output.push([date, client, project, name, "", "", ""]);
+        Logger.log(
+          `請求書風明細を検出: 日付=${date}, 広告主=${client}, 案件名=${project}, 商品名=${name}, 単価=${unit}, 件数=${qty}, 金額=${amount}`
+        );
+        output.push([date, client, project, name, unit, qty, amount]);
       }
-      itemText = ""; // 1回使ったらリセット
       matchedAny = true;
       continue;
     }


### PR DESCRIPTION
## Summary
- Capture product name from the same '内容' line instead of next line
- Parse unit price, quantity, and amount from invoice-style rows and log them

## Testing
- `node --check parseMultiFormatData`


------
https://chatgpt.com/codex/tasks/task_e_68a43465fff0832882a1c87ce627364d