### PR TITLE
Handle header-only content lines in parser

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -51,8 +51,15 @@ function parseMultiFormatData() {
         Logger.log(`内容一行形式を検出: 商品名=${name}, 単価=${unit}, 件数=${qty}, 金額=${amount}`);
         output.push(["", "", "", name, unit, qty, amount]);
       } else {
-        itemText = line.replace("内容", "").trim();
-        Logger.log(`内容行を検出: ${itemText}`);
+        // ヘッダー行のみで数値が次行に続くパターン
+        const headerMatch = line.match(/^内容\s+(.+?)\s+単価\s+数量\s+金額/);
+        if (headerMatch) {
+          itemText = headerMatch[1].trim();
+          Logger.log(`内容ヘッダーを検出: ${itemText}`);
+        } else {
+          itemText = line.replace("内容", "").trim();
+          Logger.log(`内容行を検出: ${itemText}`);
+        }
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- support multi-line invoice details where "内容" header is on one line and numeric data follows

## Testing
- `node - <<'NODE'` (custom script to validate parsing)
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a440513d288328b782f6c70c256ee9