### PR TITLE
Handle multiple entries in parseMultiFormatData

### DIFF
--- a/parseMultiFormatData
+++ b/parseMultiFormatData
@@ -42,24 +42,30 @@ function parseMultiFormatData() {
       Logger.log(`案件名を検出: ${project}`);
     }
     if (line.startsWith("内容")) {
-      const mLine = line.match(/^内容\s+(.+?)\s+単価\s+数量\s+金額\s+課税区分\s+¥([\d,]+)\s+([\d,]+)\s+¥([\d,]+)/);
-      if (mLine) {
+      const contentPattern = /内容\s+(.+?)\s+単価\s+数量\s+金額\s+課税区分\s+¥([\d,]+)\s+([\d,]+)\s+¥([\d,]+)/g;
+      let mLine;
+      let found = false;
+      while ((mLine = contentPattern.exec(line)) !== null) {
         const name = mLine[1].trim();
         const unit = parseInt(mLine[2].replace(/,/g, ''), 10);
         const qty = parseInt(mLine[3].replace(/,/g, ''), 10);
         const amount = parseInt(mLine[4].replace(/,/g, ''), 10);
         Logger.log(`内容一行形式を検出: 商品名=${name}, 単価=${unit}, 件数=${qty}, 金額=${amount}`);
         output.push(["", "", "", name, unit, qty, amount]);
+        found = true;
+      }
+      if (found) {
+        continue;
+      }
+
+      // ヘッダー行のみで数値が次行に続くパターン
+      const headerMatch = line.match(/^内容\s+(.+?)\s+単価\s+数量\s+金額/);
+      if (headerMatch) {
+        itemText = headerMatch[1].trim();
+        Logger.log(`内容ヘッダーを検出: ${itemText}`);
       } else {
-        // ヘッダー行のみで数値が次行に続くパターン
-        const headerMatch = line.match(/^内容\s+(.+?)\s+単価\s+数量\s+金額/);
-        if (headerMatch) {
-          itemText = headerMatch[1].trim();
-          Logger.log(`内容ヘッダーを検出: ${itemText}`);
-        } else {
-          itemText = line.replace("内容", "").trim();
-          Logger.log(`内容行を検出: ${itemText}`);
-        }
+        itemText = line.replace("内容", "").trim();
+        Logger.log(`内容行を検出: ${itemText}`);
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- allow parseMultiFormatData to extract multiple `内容` blocks from a single line

## Testing
- `node - <<'NODE'
const line = "内容 成果報酬 単価 数量 金額 課税区分 ¥6,650 1,054 ¥7,009,100 （外税） ---------------------------------------- 内容 成果報酬 単価 数量 金額 課税区分 ¥7,150 1,231 ¥8,801,650 （外税） ---------------------------------------- 内容 成果報酬（定期） 単価 数量 金額 課税区分 ¥26,700 94 ¥2,509,800 （外税） ----------------------------------------";
const contentPattern = /内容\s+(.+?)\s+単価\s+数量\s+金額\s+課税区分\s+¥([\d,]+)\s+([\d,]+)\s+¥([\d,]+)/g;
let mLine;
const result = [];
while ((mLine = contentPattern.exec(line)) !== null) {
  result.push({name:mLine[1], unit:mLine[2], qty:mLine[3], amount:mLine[4]});
}
console.log(result);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a44181b4548328b5bea83582fb09b3