### PR TITLE
Add monthly sheet duplication and enhance summary output

### DIFF
--- a/monthlySheetCopy.gs
+++ b/monthlySheetCopy.gs
@@ -1,0 +1,54 @@
+function copyNextMonthSheets() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var sheets = ss.getSheets();
+  var pattern = /^(\d{4})年(\d{1,2})月対応_(受領|請求発行|データ格納)$/;
+  var latestDate = null;
+  var templates = {};
+  sheets.forEach(function(sheet) {
+    var m = sheet.getName().match(pattern);
+    if (m) {
+      var year = parseInt(m[1], 10);
+      var month = parseInt(m[2], 10);
+      var type = m[3];
+      var d = new Date(year, month - 1);
+      if (!latestDate || d.getTime() > latestDate.getTime()) {
+        latestDate = d;
+      }
+      templates[type] = sheet;
+    }
+  });
+  if (!latestDate) return null;
+  var nextYear = latestDate.getFullYear();
+  var nextMonth = latestDate.getMonth() + 2;
+  if (nextMonth > 12) {
+    nextYear++;
+    nextMonth = 1;
+  }
+  var ym = nextYear + '年' + nextMonth + '月対応';
+  function copy(sheet, suffix) {
+    var copied = sheet.copyTo(ss);
+    copied.setName(ym + '_' + suffix);
+    ss.setActiveSheet(copied);
+    return copied;
+  }
+  var newReceive = templates['受領'] && copy(templates['受領'], '受領');
+  if (newReceive) newReceive.getRange('A1').setValue(ym);
+  var newInvoice = templates['請求発行'] && copy(templates['請求発行'], '請求発行');
+  if (newInvoice) {
+    newInvoice.getRange('A:E').clearContent();
+    newInvoice.getRange('G:G').clearContent();
+  }
+  var newData = templates['データ格納'] && copy(templates['データ格納'], 'データ格納');
+  if (newData) {
+    newData.getRange('O:S').clearContent();
+    newData.getRange('W:AA').clearContent();
+  }
+  return ym + '_データ格納';
+}
+
+function createNextMonthAndSummarize() {
+  var dataSheetName = copyNextMonthSheets();
+  if (dataSheetName) {
+    summarizeResultsByAgency(dataSheetName);
+  }
+}

--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -1,4 +1,4 @@
-function summarizeResultsByAgency() {
+function summarizeResultsByAgency(targetSheetName) {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
   var inputSheet = ss.getSheets()[0];
   var start = inputSheet.getRange('B2').getValue();
@@ -201,42 +201,45 @@ function summarizeResultsByAgency() {
     outSheet.getRange(2, 1, rows.length, 7).setValues(rows);
   }
 
-  var outSheet3 = ss.getSheetByName('シート3') || ss.getSheetByName('Sheet3');
-  if (!outSheet3) {
-    outSheet3 = ss.insertSheet('シート3');
-  }
-  outSheet3.clearContents();
-  outSheet3.getRange(1, 1, 1, 10).setValues([[
-    'アフィリエイター',
-    '成果名',
-    '広告主',
-    '成果報酬額（グロス）[円]',
-    '成果報酬額（ネット）[円]',
-    '広告',
-    '発生成果数[件]',
-    '発生成果額（グロス）[円]',
-    '確定成果数[件]',
-    '確定成果額（グロス）[円]'
-  ]]);
+  var summarySheet = ss.getSheetByName(targetSheetName) || ss.getSheetByName('2025年8月対応_データ格納');
+  if (summarySheet) {
+    summarySheet.getRange(1, 15, 1, 5).setValues([[
+      'アフィリエイター',
+      '成果名',
+      '広告主',
+      '成果報酬額（グロス）[円]',
+      '成果報酬額（ネット）[円]'
+    ]]);
+    summarySheet.getRange(1, 23, 1, 5).setValues([[
+      '広告',
+      '発生成果数[件]',
+      '発生成果額（グロス）[円]',
+      '確定成果数[件]',
+      '確定成果額（グロス）[円]'
+    ]]);
 
-  var rows3 = [];
-  for (var k3 in summary3) {
-    var s3 = summary3[k3];
-    rows3.push([
-      s3.affiliate,
-      s3.subject,
-      s3.advertiser,
-      s3.grossReward,
-      s3.netReward,
-      s3.ad,
-      s3.generatedCount,
-      s3.generatedGross,
-      s3.confirmedCount,
-      s3.confirmedGross
-    ]);
-  }
-
-  if (rows3.length > 0) {
-    outSheet3.getRange(2, 1, rows3.length, 10).setValues(rows3);
+    var rowsLeft = [];
+    var rowsRight = [];
+    for (var k3 in summary3) {
+      var s3 = summary3[k3];
+      rowsLeft.push([
+        s3.affiliate,
+        s3.subject,
+        s3.advertiser,
+        s3.grossReward,
+        s3.netReward
+      ]);
+      rowsRight.push([
+        s3.ad,
+        s3.generatedCount,
+        s3.generatedGross,
+        s3.confirmedCount,
+        s3.confirmedGross
+      ]);
+    }
+    if (rowsLeft.length > 0) {
+      summarySheet.getRange(2, 15, rowsLeft.length, 5).setValues(rowsLeft);
+      summarySheet.getRange(2, 23, rowsRight.length, 5).setValues(rowsRight);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `copyNextMonthSheets` to duplicate latest monthly sheets and clear specified columns
- Extend `summarizeResultsByAgency` to write summary data into existing data storage sheet columns O-S and W-AA

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bfbc36f48328b5502ea8e8baeca0