### PR TITLE
Aggregate approved data by confirmation date

### DIFF
--- a/monthlySheetCopy.gs
+++ b/monthlySheetCopy.gs
@@ -1,0 +1,67 @@
+function monthlySheetCopy() {
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var inputSheet = ss.getSheets()[0];
+  var start = inputSheet.getRange('B2').getValue();
+  var end = inputSheet.getRange('C2').getValue();
+  if (!(start instanceof Date) || !(end instanceof Date)) {
+    SpreadsheetApp.getUi().alert('B2/C2 に日付が入力されていません。');
+    return;
+  }
+
+  var baseUrl = 'https://otonari-asp.com/api/v1/m';
+  var accessKey = 'agqnoournapf';
+  var secretKey = '1kvu9dyv1alckgocc848socw';
+  baseUrl = baseUrl.replace(/\/+$, '');
+  var headers = { 'X-Auth-Token': accessKey + ':' + secretKey };
+
+  var params = [
+    'approve_unix=between_date',
+    'approve_unix_A_Y=' + start.getFullYear(),
+    'approve_unix_A_M=' + (start.getMonth() + 1),
+    'approve_unix_A_D=' + start.getDate(),
+    'approve_unix_B_Y=' + end.getFullYear(),
+    'approve_unix_B_M=' + (end.getMonth() + 1),
+    'approve_unix_B_D=' + end.getDate(),
+    'state[]=2',
+    'limit=500',
+    'offset=0'
+  ];
+
+  var records = [];
+  var offset = 0;
+  while (true) {
+    params[params.length - 1] = 'offset=' + offset;
+    var url = baseUrl + '/action_log_raw/search?' + params.join('&');
+    var response;
+    try {
+      response = UrlFetchApp.fetch(url, { method: 'get', headers: headers });
+    } catch (e) {
+      SpreadsheetApp.getUi().alert('API取得に失敗しました: ' + e);
+      return;
+    }
+    var json = JSON.parse(response.getContentText());
+    if (json.records && json.records.length) {
+      records = records.concat(json.records);
+    }
+    var count = json.header && json.header.count ? json.header.count : 0;
+    if (records.length >= count) {
+      break;
+    }
+    offset += json.records.length;
+  }
+
+  var sheetName = '月次コピー';
+  var outSheet = ss.getSheetByName(sheetName) || ss.insertSheet(sheetName);
+  outSheet.clearContents();
+
+  if (records.length === 0) {
+    return;
+  }
+
+  var keys = Object.keys(records[0]);
+  outSheet.getRange(1, 1, 1, keys.length).setValues([keys]);
+  var rows = records.map(function(rec) {
+    return keys.map(function(k) { return rec[k]; });
+  });
+  outSheet.getRange(2, 1, rows.length, keys.length).setValues(rows);
+}

--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -15,14 +15,13 @@ function summarizeResultsByAgency() {
   var headers = { 'X-Auth-Token': accessKey + ':' + secretKey };
 
   var params = [
-    'apply_unix=between_date',
-    'apply_unix_A_Y=' + start.getFullYear(),
-    'apply_unix_A_M=' + (start.getMonth() + 1),
-    'apply_unix_A_D=' + start.getDate(),
-    'apply_unix_B_Y=' + end.getFullYear(),
-    'apply_unix_B_M=' + (end.getMonth() + 1),
-    'apply_unix_B_D=' + end.getDate(),
-    'state[]=1',
+    'approve_unix=between_date',
+    'approve_unix_A_Y=' + start.getFullYear(),
+    'approve_unix_A_M=' + (start.getMonth() + 1),
+    'approve_unix_A_D=' + start.getDate(),
+    'approve_unix_B_Y=' + end.getFullYear(),
+    'approve_unix_B_M=' + (end.getMonth() + 1),
+    'approve_unix_B_D=' + end.getDate(),
     'state[]=2',
     'limit=500',
     'offset=0'
@@ -138,21 +137,16 @@ function summarizeResultsByAgency() {
         grossReward: grossReward,
         netReward: netReward,
         ad: ad,
-        generatedCount: 0,
-        generatedGross: 0,
         confirmedCount: 0,
         confirmedGross: 0
       };
     }
-    if (Number(rec.state) === 1) {
-      summary3[key3].generatedCount++;
-      summary3[key3].generatedGross += grossReward;
-    } else if (Number(rec.state) === 2) {
+    if (Number(rec.state) === 2) {
       summary3[key3].confirmedCount++;
       summary3[key3].confirmedGross += grossReward;
     }
 
-    if (Number(rec.state) !== 1) return;
+    if (Number(rec.state) !== 2) return;
     var key = agency + '\u0000' + manager + '\u0000' + ad + '\u0000' + affiliate;
     if (!summary[key]) {
       summary[key] = {
@@ -206,15 +200,13 @@ function summarizeResultsByAgency() {
     outSheet3 = ss.insertSheet('シート3');
   }
   outSheet3.clearContents();
-  outSheet3.getRange(1, 1, 1, 10).setValues([[
+  outSheet3.getRange(1, 1, 1, 8).setValues([[
     'アフィリエイター',
     '成果名',
     '広告主',
     '成果報酬額（グロス）[円]',
     '成果報酬額（ネット）[円]',
     '広告',
-    '発生成果数[件]',
-    '発生成果額（グロス）[円]',
     '確定成果数[件]',
     '確定成果額（グロス）[円]'
   ]]);
@@ -229,14 +221,12 @@ function summarizeResultsByAgency() {
       s3.grossReward,
       s3.netReward,
       s3.ad,
-      s3.generatedCount,
-      s3.generatedGross,
       s3.confirmedCount,
       s3.confirmedGross
     ]);
   }
 
   if (rows3.length > 0) {
-    outSheet3.getRange(2, 1, rows3.length, 10).setValues(rows3);
+    outSheet3.getRange(2, 1, rows3.length, 8).setValues(rows3);
   }
 }


### PR DESCRIPTION
## Summary
- Collect monthly records approved within a specified period
- Filter agency ad summary to confirmed approvals only

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c0a07f088328a57c08eef11abeb2