### PR TITLE
Use start-date month for summary sheet fallback

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -209,7 +209,8 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     if (summarySheet) {
       Logger.log('summarizeApprovedResultsByAgency: detected latest data sheet ' + summarySheet.getName());
     } else {
-      summarySheet = ss.getSheetByName('2025年8月対応_データ格納');
+      var fallbackName = Utilities.formatDate(start, Session.getScriptTimeZone(), 'yyyy年M月対応_データ格納');
+      summarySheet = ss.getSheetByName(fallbackName);
       Logger.log('summarizeApprovedResultsByAgency: fallback to sheet ' + (summarySheet ? summarySheet.getName() : 'none'));
     }
   }


### PR DESCRIPTION
## Summary
- derive fallback summary sheet name from the start date instead of a hard-coded month

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e3ae44b88328a9a2ec3935fbc040