### PR TITLE
Prevent infinite loop when API returns no records

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -49,14 +49,18 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
         return null;
       }
       var json = JSON.parse(response.getContentText());
-      if (json.records && json.records.length) {
+      var fetched = json.records && json.records.length ? json.records.length : 0;
+      if (fetched > 0) {
         result = result.concat(json.records);
-      }
-      var count = json.header && json.header.count ? json.header.count : 0;
-      if (result.length >= count) {
+      } else {
+        Logger.log('summarizeApprovedResultsByAgency: no records returned, breaking');
         break;
       }
-      offset += json.records.length;
+      var count = json.header && json.header.count ? json.header.count : 0;
+      if (result.length >= count || offset >= count) {
+        break;
+      }
+      offset += fetched;
     }
     return result;
   }


### PR DESCRIPTION
## Summary
- Stop `summarizeApprovedResultsByAgency` from hanging when API returns zero records by exiting loop early
- Guard against offset not progressing to avoid endless iteration

## Testing
- `node --check summarizeAgencyAds.gs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a810bf90748328931f6f285e11f1f8