### PR TITLE
Improve error logging for summarizeAgencyAds

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -53,6 +53,7 @@ function alertUi_(message) {
 function summarizeApprovedResultsByAgency(targetSheetName) {
   Logger.log('summarizeApprovedResultsByAgency: start' + (targetSheetName ? ' target=' + targetSheetName : ''));
   showProgress_();
+  try {
   var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
   var dateSheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
   var start = dateSheet.getRange('B2').getValue();
@@ -474,4 +475,9 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   }
   setProgress_(100, '処理完了', TOTAL_STEPS, TOTAL_STEPS);
   Logger.log('summarizeApprovedResultsByAgency: complete');
+  } catch (e) {
+    Logger.log('summarizeApprovedResultsByAgency: error ' + e + (e.stack ? '\n' + e.stack : ''));
+    alertUi_('エラーが発生しました: ' + e);
+    setProgress_(100, 'エラー: ' + e, 0, TOTAL_STEPS);
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap `summarizeApprovedResultsByAgency` in try/catch to capture unexpected errors
- Log stack trace and notify UI when an error occurs for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc4f766848328b6a6a13e311e3a98