### PR TITLE
アフィリエイター名の詳細追加と広告集計の重複排除

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -226,7 +226,10 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     return rec && rec.name;
   });
   fetchNames(Object.keys(mediaSet), 'media', mediaMap, function(rec) {
-    return rec && rec.name;
+    if (!rec) return '';
+    var company = rec.company || '';
+    var name = rec.name || '';
+    return company && name ? company + ' ' + name : (company || name);
   });
   setProgress_(60, 'マスタ情報取得完了', 4, TOTAL_STEPS);
 
@@ -285,12 +288,12 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     summary3[key3].generatedCount++;
     summary3[key3].generatedGross += grossReward;
 
-    var keyAd = ad + '\u0000' + grossReward + '\u0000' + netReward;
+    var keyAd = ad + '\u0000' + grossUnit + '\u0000' + netUnit;
     if (!summaryByAd[keyAd]) {
       summaryByAd[keyAd] = {
         ad: ad,
-        grossReward: grossReward,
-        netReward: netReward,
+        grossUnit: grossUnit,
+        netUnit: netUnit,
         generatedCount: 0,
         generatedGross: 0,
         confirmedCount: 0,
@@ -331,12 +334,12 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     summary3[key3].confirmedCount++;
     summary3[key3].confirmedGross += grossReward;
 
-    var keyAd = ad + '\u0000' + grossReward + '\u0000' + netReward;
+    var keyAd = ad + '\u0000' + grossUnit + '\u0000' + netUnit;
     if (!summaryByAd[keyAd]) {
       summaryByAd[keyAd] = {
         ad: ad,
-        grossReward: grossReward,
-        netReward: netReward,
+        grossUnit: grossUnit,
+        netUnit: netUnit,
         generatedCount: 0,
         generatedGross: 0,
         confirmedCount: 0,


### PR DESCRIPTION
## Summary
- O列のアフィリエイター名を会社名+氏名の形式で出力
- W~AA列の広告集計をグロス/ネット単価が一致するもの同士で統合

## Testing
- `cp summarizeAgencyAds.gs tmp.js && node --check tmp.js && rm tmp.js`


------
https://chatgpt.com/codex/tasks/task_e_68abd50be294832887a34608bf7485fd