### PR TITLE
Fix confirmation logic in summarizeAgencyAds.gs

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -77,6 +77,7 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   function fetchRecords(dateField, states) {
     var apiEnd = new Date(end.getTime());
     apiEnd.setDate(apiEnd.getDate() + 1);
+    apiEnd.setHours(0, 0, 0, 0);
     Logger.log('fetchRecords: ' + dateField + ' を between_date で ' + start + ' ～ ' + end +
       '（API検索は翌日0時まで）' +
       (states && states.length ? '、state=' + states.join(',') : '、state 指定なし') + ' の条件で検索');
@@ -143,7 +144,7 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
 
   function fetchConfirmedRecords() {
     // 確定成果は承認日時で抽出
-    return fetchRecords('apply_unix', ['2']);
+    return fetchRecords('approve_unix', ['2']);
   }
 
   function filterRecords(records, unixField, dateField) {
@@ -167,8 +168,8 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   var confirmedRecords = fetchConfirmedRecords();
   if (confirmedRecords === null) { setProgress_(100, 'エラー: 確定成果の取得に失敗しました', 3, TOTAL_STEPS); return; }
   var confirmedFetched = confirmedRecords.length;
-  confirmedRecords = filterRecords(confirmedRecords, 'apply_unix', 'apply_at');
-  Logger.log('確定成果の取得ロジック: apply_unix または apply_at が期間内で state=2 のレコードを対象。API取得件数=' + confirmedFetched + '件、フィルタ後=' + confirmedRecords.length + '件');
+  confirmedRecords = filterRecords(confirmedRecords, 'approve_unix', 'approve_at');
+  Logger.log('確定成果の取得ロジック: approve_unix または approve_at が期間内で state=2 のレコードを対象。API取得件数=' + confirmedFetched + '件、フィルタ後=' + confirmedRecords.length + '件');
   setProgress_(50, '確定成果取得完了', 3, TOTAL_STEPS);
   var records = generatedRecords.concat(confirmedRecords);
   Logger.log('summarizeApprovedResultsByAgency: fetched ' + generatedRecords.length + ' generated record(s) and ' + confirmedRecords.length + ' confirmed record(s)');


### PR DESCRIPTION
## Summary
- ensure API date range ends at next day's midnight
- count confirmed results using approval dates (`approve_unix`)

## Testing
- ⚠️ `node --check summarizeAgencyAds.gs` *(fails: Unknown file extension ".gs")*

------
https://chatgpt.com/codex/tasks/task_e_68abf47c7d98832893bf2313c2a8b9da