### PR TITLE
Handle non-ISO date strings in summarizeAgencyAds

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -144,12 +144,17 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   function filterRecords(records, unixField, dateField) {
     return records.filter(function(rec) {
       var d = null;
-      if (rec[unixField]) {
-        d = new Date(Number(rec[unixField]) * 1000);
+      var unixVal = rec[unixField];
+      if (unixVal !== undefined && unixVal !== null && unixVal !== '') {
+        d = new Date(Number(unixVal) * 1000);
       } else if (rec[dateField]) {
-        d = new Date(rec[dateField]);
+        var str = String(rec[dateField]).replace(' ', 'T');
+        d = new Date(str);
+        if (isNaN(d.getTime())) {
+          d = new Date(str.replace(/-/g, '/'));
+        }
       }
-      return d && d.getTime() >= start.getTime() && d.getTime() < end.getTime();
+      return d && !isNaN(d.getTime()) && d.getTime() >= start.getTime() && d.getTime() < end.getTime();
     });
   }
 


### PR DESCRIPTION
## Summary
- fix record filtering to parse `approve_at` and similar date strings that use spaces
- fall back to replacing dashes when parsing fails to avoid dropping records

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abfa35c11483289d27f02c05c6345f