### PR TITLE
Fix agency ad summary not running

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -55,7 +55,7 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   showProgress_();
   try {
   var ss = SpreadsheetApp.openById(SPREADSHEET_ID);
-  var dateSheet = SpreadsheetApp.getActiveSpreadsheet().getSheets()[0];
+  var dateSheet = ss.getSheets()[0];
   var start = dateSheet.getRange('B2').getValue();
   var end = dateSheet.getRange('C2').getValue();
   if (!(start instanceof Date) || !(end instanceof Date)) {
@@ -559,4 +559,8 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     alertUi_('エラーが発生しました: ' + e);
     setProgress_(100, 'エラー: ' + e, 0, TOTAL_STEPS);
   }
+}
+
+function summarizeAgencyAds(targetSheetName) {
+  summarizeApprovedResultsByAgency(targetSheetName);
 }


### PR DESCRIPTION
## Summary
- Read date range from the opened spreadsheet instead of an inactive context
- Expose `summarizeAgencyAds` function that calls the main summary routine

## Testing
- `node --check summarizeAgencyAds.gs` *(fails: Unknown file extension ".gs")*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e4dc5ec8328b77388fac0b6c0c8