### PR TITLE
Add startup log to summarizeAgencyAds for debugging

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -574,5 +574,6 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   }
 
 function summarizeAgencyAds(targetSheetName) {
+  Logger.log('処理を開始します');
   showProgress_(targetSheetName);
 }


### PR DESCRIPTION
## Summary
- log start of summarizeAgencyAds execution for easier debugging

## Testing
- `node --check < summarizeAgencyAds.gs`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac25c0c83c8328809505dd911aa684