### PR TITLE
Separate sheet IDs for output and date data

### DIFF
--- a/monthlySheetCopy.gs
+++ b/monthlySheetCopy.gs
@@ -1,4 +1,5 @@
-var SPREADSHEET_ID = '13zQMfgfYlec1BOo0LwWZUerQD9Fm0Fkzav8Z20d5eDE';
+// Spreadsheet where new monthly sheets are created and summary results are stored
+var SPREADSHEET_ID = '1qkae2jGCUlykwL-uTf0_eaBGzon20RCC-wBVijyvm8s';
 
 function copyNextMonthSheets() {
   Logger.log('copyNextMonthSheets: start');


### PR DESCRIPTION
## Summary
- Add distinct IDs for output and date-range spreadsheets in `summarizeAgencyAds.gs`
- Update summary logic to read dates from the dedicated sheet while writing results to the target sheet
- Use the new target spreadsheet ID in `monthlySheetCopy.gs`

## Testing
- `node --check --input-type=module < summarizeAgencyAds.gs`
- `node --check --input-type=module < monthlySheetCopy.gs`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ce331fc8328b0d66a7f3be7aa6c