### PR TITLE
Use apply_unix without state for confirmed data retrieval

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -161,8 +161,8 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   }
 
   function fetchConfirmedRecords() {
-    // 確定成果は確定日時で抽出
-    return fetchRecords('apply_unix', ['2']);
+    // 確定成果は state を指定せずに確定日時 (apply_unix) で抽出
+    return fetchRecords('apply_unix');
   }
 
   function formatDateForLog(date) {


### PR DESCRIPTION
## Summary
- fetch confirmed records using only `apply_unix` and avoid specifying state

## Testing
- `node --check /tmp/summarizeAgencyAds.js`

------
https://chatgpt.com/codex/tasks/task_e_68ad222134488328a2527f1499b55770