### PR TITLE
Use state=1 for confirmed data

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -161,8 +161,8 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   }
 
   function fetchConfirmedRecords() {
-    // 確定成果は state を指定せずに確定日時 (apply_unix) で抽出
-    return fetchRecords('apply_unix');
+    // 確定成果は state=1 を指定して確定日時 (apply_unix) で抽出
+    return fetchRecords('apply_unix', [1]);
   }
 
   function formatDateForLog(date) {
@@ -202,7 +202,7 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     throw new Error('確定成果の取得に失敗しました');
   }
   counts.confirmed = confirmedRecords.length;
-  Logger.log('fetchConfirmedRecords: state=2 で取得した件数=' + confirmedRecords.length + '件');
+  Logger.log('fetchConfirmedRecords: state=1 で取得した件数=' + confirmedRecords.length + '件');
   if (confirmedRecords.length > 0) {
     Logger.log('例: 確定成果の一部: ' + JSON.stringify(confirmedRecords[0]));
   }


### PR DESCRIPTION
## Summary
- filter confirmed results with state=1 and apply_unix
- update logging to reflect state=1

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad236a0b588328be4f367cec5705fd