### PR TITLE
feat: use fixed spreadsheet id

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -1,5 +1,7 @@
+var TARGET_SPREADSHEET_ID = '1qkae2jGCUlykwL-uTf0_eaBGzon20RCC-wBVijyvm8s';
+
 function classifyResultsByClientSheet(records, startDate, endDate) {
-  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
   var clientSheet = ss.getSheetByName('クライアント情報');
   if (!clientSheet) {
     SpreadsheetApp.getUi().alert('クライアント情報シートが見つかりません');


### PR DESCRIPTION
## Summary
- use fixed spreadsheet ID when classifying results by client sheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad54045aa4832881a411507c107153