### PR TITLE
Integrate client classification into summary workflow

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -28,8 +28,9 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
   var result = {};  // advertiser -> {generated: [], confirmed: []}
   var notFound = [];
 
-  // Guard against undefined or non-array records to avoid runtime errors
+  // Guard against undefined or non-array records to avoid runtime errors.
   if (!Array.isArray(records)) {
+    Logger.log('classifyResultsByClientSheet: records is not an array');
     records = [];
   }
 

--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -214,6 +214,12 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   var records = generatedRecords.concat(confirmedRecords);
   Logger.log('summarizeApprovedResultsByAgency: fetched ' + generatedRecords.length + ' generated record(s) and ' + confirmedRecords.length + ' confirmed record(s)');
 
+  // Classify records using client sheet information to integrate with the
+  // summarization workflow. Any missing mappings will be reported in the
+  // "該当無し" sheet.
+  var classifiedByClient = classifyResultsByClientSheet(records, start, end);
+  Logger.log('classifyResultsByClientSheet: processed ' + Object.keys(classifiedByClient).length + ' advertiser(s)');
+
   var advertiserMap = {};
   var userMap = {};
   var promotionMap = {};


### PR DESCRIPTION
## Summary
- Log and handle non-array inputs in client classification
- Invoke classification from summary script to surface missing client mappings

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad55cfbc0c8328b1a6de399ec05426