### PR TITLE
Process results sequentially by unique advertiser-ad pairs

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -80,3 +80,32 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
 
   return result;
 }
+
+/**
+ * After copying records to a sheet, process them sequentially based on
+ * unique advertiser and ad name pairs found in columns V and W.
+ *
+ * @param {GoogleAppsScript.Spreadsheet.Sheet} sheet The sheet containing
+ *     the copied records. If omitted, the active sheet of the target
+ *     spreadsheet is used.
+ */
+function processUniqueAdvertiserAds(sheet) {
+  var ss = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
+  sheet = sheet || ss.getActiveSheet();
+  var lastRow = sheet.getLastRow();
+  if (lastRow < 2) return;
+
+  // Retrieve advertiser (V) and ad name (W) columns starting from row 2.
+  var values = sheet.getRange(2, 22, lastRow - 1, 2).getValues();
+  var seen = {};
+  for (var i = 0; i < values.length; i++) {
+    var adv = values[i][0];
+    var ad = values[i][1];
+    if (!adv && !ad) continue;
+    var key = adv + '\u0000' + ad;
+    if (seen[key]) continue;
+    seen[key] = true;
+    Logger.log('Processing advertiser=' + adv + ', ad=' + ad);
+    // ここで広告主と広告名ごとの処理を行う
+  }
+}


### PR DESCRIPTION
## Summary
- add `processUniqueAdvertiserAds` to iterate sequentially over unique advertiser/ad name pairs from columns V and W after copying data

## Testing
- `node --check classifyResults.gs` *(fails: Unknown file extension ".gs"; re-run with stdin)*
- `node --check --input-type=module - < classifyResults.gs`

------
https://chatgpt.com/codex/tasks/task_e_68ad5d01df4c8328af5f6ca5939f3ffb