### PR TITLE
Show advertiser info in missing mapping

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -49,11 +49,12 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
   }
 
   records.forEach(function(rec) {
-    var adv = rec.advertiser || rec.advertiser_name || rec.advertiserName || '';
+    var advId = rec.advertiser || rec.advertiser_name || rec.advertiserName || '';
+    var advName = rec.advertiser_name || rec.advertiserName || advId;
     var ad = rec.ad || rec.ad_name || rec.adName || '';
-    var state = (mapByAdvAd[adv] && mapByAdvAd[adv][ad]) || mapByAdv[adv];
+    var state = (mapByAdvAd[advId] && mapByAdvAd[advId][ad]) || mapByAdv[advId];
     if (!state) {
-      notFound.push([adv, ad]);
+      notFound.push([advName, ad]);
       return;
     }
 
@@ -64,9 +65,9 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
     else if (str) d = new Date(String(str).replace(' ', 'T'));
     if (!d || d < startDate || d > endDate) return;
 
-    if (!result[adv]) result[adv] = { generated: [], confirmed: [] };
-    if (state === '発生') result[adv].generated.push(rec);
-    else result[adv].confirmed.push(rec);
+    if (!result[advId]) result[advId] = { generated: [], confirmed: [] };
+    if (state === '発生') result[advId].generated.push(rec);
+    else result[advId].confirmed.push(rec);
   });
 
   if (notFound.length > 0) {

--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -594,6 +594,13 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
     Logger.log('summarizeApprovedResultsByAgency: wrote ' + rowsLeft.length + ' row(s) (left) and ' + rowsRight.length + ' row(s) (right) to ' + summarySheet.getName());
   }
 
+  // Replace advertiser IDs with readable company and contact names so that
+  // the "該当無し" sheet shows human-friendly information instead of raw IDs.
+  records.forEach(function(rec) {
+    var advId = (rec.advertiser || rec.advertiser === 0) ? rec.advertiser : promotionAdvertiserMap[rec.promotion];
+    rec.advertiser_name = advId ? (advertiserMap[advId] || advId) : '';
+  });
+
   // Classify records using client sheet information after all processing is complete.
   // Any missing mappings will be reported in the "該当無し" sheet.
   var classifiedByClient = classifyResultsByClientSheet(records, start, end);


### PR DESCRIPTION
## Summary
- Replace advertiser IDs with company + contact names before classifying results
- Use human-readable advertiser names in `該当無し` sheet instead of raw IDs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7a812cd0832884f49cf705cb7749