### PR TITLE
Handle advertiser IDs when summarizing agency ads

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -23,19 +23,19 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
   }
 
   var data = clientSheet.getDataRange().getValues();
-  var mapByAdv = {};      // advertiser -> state
-  var mapByAdvAd = {};    // advertiser -> (ad -> state)
+  var mapByAdv = {};      // advertiser ID -> state
+  var mapByAdvAd = {};    // advertiser ID -> (ad -> state)
 
   for (var i = 1; i < data.length; i++) {
-    var adName = data[i][0];       // A column
-    var advertiser = data[i][1];   // B column
-    var state = data[i][13];       // N column (index 13)
-    if (!advertiser) continue;
+    var adName = data[i][0];        // A column
+    var advertiserId = data[i][14]; // O column
+    var state = data[i][13];        // N column (index 13)
+    if (!advertiserId) continue;
     if (adName) {
-      if (!mapByAdvAd[advertiser]) mapByAdvAd[advertiser] = {};
-      mapByAdvAd[advertiser][adName] = state;
+      if (!mapByAdvAd[advertiserId]) mapByAdvAd[advertiserId] = {};
+      mapByAdvAd[advertiserId][adName] = state;
     } else {
-      mapByAdv[advertiser] = state;
+      mapByAdv[advertiserId] = state;
     }
   }
 
@@ -49,7 +49,7 @@ function classifyResultsByClientSheet(records, startDate, endDate) {
   }
 
   records.forEach(function(rec) {
-    var advId = rec.advertiser || rec.advertiser_name || rec.advertiserName || '';
+    var advId = rec.advertiserId || rec.advertiser || rec.advertiser_name || rec.advertiserName || '';
     var advName = rec.advertiser_name || rec.advertiserName || advId;
     var ad = rec.ad || rec.ad_name || rec.adName || '';
     var state = (mapByAdvAd[advId] && mapByAdvAd[advId][ad]) || mapByAdv[advId];


### PR DESCRIPTION
## Summary
- append advertiser ID to column AB when outputting agency summary and avoid creating Sheet2 automatically
- match client records using advertiser ID from column O

## Testing
- `node --check --input-type=module < summarizeAgencyAds.gs`
- `node --check --input-type=module < classifyResults.gs`


------
https://chatgpt.com/codex/tasks/task_e_68ad831806148328ad5e082612cc68de