### PR TITLE
Use named date sheet

### DIFF
--- a/classifyResults.gs
+++ b/classifyResults.gs
@@ -1,11 +1,11 @@
 var TARGET_SPREADSHEET_ID = '1qkae2jGCUlykwL-uTf0_eaBGzon20RCC-wBVijyvm8s';
 var DATE_SPREADSHEET_ID = '13zQMfgfYlec1BOo0LwWZUerQD9Fm0Fkzav8Z20d5eDE';
-var DATE_SHEET_ID = 0;
+var DATE_SHEET_NAME = '日付';
 
 function classifyResultsByClientSheet(records, startDate, endDate) {
   if (!(startDate instanceof Date) || !(endDate instanceof Date)) {
     var dateSs = SpreadsheetApp.openById(DATE_SPREADSHEET_ID);
-    var dateSheet = dateSs.getSheetById(DATE_SHEET_ID);
+    var dateSheet = dateSs.getSheetByName(DATE_SHEET_NAME);
     startDate = dateSheet.getRange('B2').getValue();
     endDate = dateSheet.getRange('C2').getValue();
   }

--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -6,7 +6,7 @@
 var TARGET_SPREADSHEET_ID = '1qkae2jGCUlykwL-uTf0_eaBGzon20RCC-wBVijyvm8s';
 // Spreadsheet that holds the date range used for the summary
 var DATE_SPREADSHEET_ID = '13zQMfgfYlec1BOo0LwWZUerQD9Fm0Fkzav8Z20d5eDE';
-var DATE_SHEET_ID = 0;
+var DATE_SHEET_NAME = '日付';
 var PROGRESS_KEY = 'SUMMARY_PROGRESS';
 var TOTAL_STEPS = 7;
 
@@ -72,7 +72,7 @@ function summarizeApprovedResultsByAgency(targetSheetName) {
   var counts = { confirmed: 0, generated: 0, adListRows: 0, outSheetRows: 0, summaryLeftRows: 0, summaryRightRows: 0, summarySheetName: '' };
   var targetSs = SpreadsheetApp.openById(TARGET_SPREADSHEET_ID);
   var dateSs = SpreadsheetApp.openById(DATE_SPREADSHEET_ID);
-  var dateSheet = dateSs.getSheetById(DATE_SHEET_ID);
+  var dateSheet = dateSs.getSheetByName(DATE_SHEET_NAME);
   var start = dateSheet.getRange('B2').getValue();
   var end = dateSheet.getRange('C2').getValue();
   if (!(start instanceof Date) || !(end instanceof Date)) {


### PR DESCRIPTION
## Summary
- Retrieve date range from the sheet named "日付" in the date spreadsheet for both summarizeAgencyAds.gs and classifyResults.gs

## Testing
- `node -e "new Function(require('fs').readFileSync('summarizeAgencyAds.gs','utf8')); console.log('summarize ok')" && node -e "new Function(require('fs').readFileSync('classifyResults.gs','utf8')); console.log('classify ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68ae5ef3db148328aa1d12308d12cc82