### PR TITLE
Sort invoice output by advertiser

### DIFF
--- a/summarizeAgencyAds.gs
+++ b/summarizeAgencyAds.gs
@@ -656,7 +656,9 @@ function classifyResultsByClientSheet(summarySheet) {
       merged[key][5] += amount;
     });
     invoiceRows = Object.keys(merged).map(function(k) { return merged[k]; });
-    invoiceSheet.getRange(2, 1, invoiceRows.length, 6).setValues(invoiceRows);
+    var invoiceRange = invoiceSheet.getRange(2, 1, invoiceRows.length, 6);
+    invoiceRange.setValues(invoiceRows);
+    invoiceRange.sort({ column: 2, ascending: true });
   }
   if (unmatchedRows.length > 0) {
     unmatchedSheet.getRange(2, 1, unmatchedRows.length, 7).setValues(unmatchedRows);


### PR DESCRIPTION
## Summary
- Sort "発行" invoice sheet by advertiser name after populating data.

## Testing
- `node --check < summarizeAgencyAds.gs`


------
https://chatgpt.com/codex/tasks/task_e_68aff360eb4c8328a732824f68f130a4