### PR TITLE
Handle affiliate exclusion by checking genre sheet

### DIFF
--- a/receiptByAffiliate.gs
+++ b/receiptByAffiliate.gs
@@ -182,11 +182,19 @@ function summarizeConfirmedResultsByAffiliate() {
     var ad = rec.promotion ? (promotionMap[rec.promotion] || rec.promotion) : '';
     var affiliateInfo = (rec.media || rec.media === 0) ? (mediaMap[rec.media] || { company: toFullWidthSpace_(String(rec.media)), person: '' }) : { company: '', person: '' };
 
-    var personKey = affiliateInfo.person;
-    var excluded = personKey && excludedNames[personKey];
-    if (!excluded && affiliateInfo.company && affiliateInfo.person) {
-      var combinedKey = toFullWidthSpace_(affiliateInfo.company + ' ' + affiliateInfo.person);
+    var excluded = false;
+    if (affiliateInfo.company && affiliateInfo.person) {
+      // Try matching without space between company and name.
+      var combinedKey = toFullWidthSpace_(affiliateInfo.company + affiliateInfo.person);
       excluded = excludedNames[combinedKey];
+      if (!excluded) {
+        // If not found, insert a space and try again.
+        combinedKey = toFullWidthSpace_(affiliateInfo.company + ' ' + affiliateInfo.person);
+        excluded = excludedNames[combinedKey];
+      }
+    } else {
+      var personKey = affiliateInfo.person;
+      excluded = personKey && excludedNames[personKey];
     }
     if (excluded) return; // Skip excluded affiliates
 


### PR DESCRIPTION
## Summary
- Search the "【毎月更新】ジャンル" sheet for each affiliate using both concatenated and space-separated company/name combinations
- Skip receipts for affiliates found in the genre sheet, leaving only non-matching affiliates in the summary

## Testing
- `node --check Creative/receiptByAffiliate.gs` *(fails: Unknown file extension ".gs" for Node's syntax check)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affff585bc8328b9371a9e580a3042