### PR TITLE
Fix affiliate company retrieval in receipts summary

### DIFF
--- a/receiptByAffiliate.gs
+++ b/receiptByAffiliate.gs
@@ -145,7 +145,8 @@ function summarizeConfirmedResultsByAffiliate() {
     return { company: rec.name || '', user: rec.user || '' };
   });
   fetchNames(Object.keys(userSet), 'user', userMap, function(rec) {
-    return rec && rec.name;
+    if (!rec) return { company: '', name: '' };
+    return { company: rec.company || '', name: rec.name || '' };
   });
 
   var advertiserMap = {}, mediaMap = {};
@@ -158,10 +159,10 @@ function summarizeConfirmedResultsByAffiliate() {
   });
   Object.keys(mediaInfoMap).forEach(function(id) {
     var info = mediaInfoMap[id];
-    var person = info.user ? (userMap[info.user] || '') : '';
+    var userInfo = info.user ? userMap[info.user] : null;
     mediaMap[id] = {
-      company: toFullWidthSpace_(info.company || ''),
-      person: toFullWidthSpace_(person || '')
+      company: toFullWidthSpace_((userInfo && userInfo.company) || info.company || ''),
+      person: toFullWidthSpace_((userInfo && userInfo.name) || '')
     };
   });
 


### PR DESCRIPTION
## Summary
- fetch user company and name when building receipt summaries
- map media entries to user company to avoid showing account IDs

## Testing
- `node --check temp.js`

------
https://chatgpt.com/codex/tasks/task_e_68b01d42233083288ddc9ac6cd9a6944