### PR TITLE
Fix affiliate search query parameters

### DIFF
--- a/applyAffiliatePartnerships.gs
+++ b/applyAffiliatePartnerships.gs
@@ -224,7 +224,6 @@ function buildAffiliateSearchParams(parsed, originalName) {
 
   if (parsed.company && parsed.name) {
     paramsList.push({ company: parsed.company, name: parsed.name });
-    paramsList.push({ keyword: parsed.company + ' ' + parsed.name });
   }
 
   if (parsed.company) {
@@ -237,7 +236,6 @@ function buildAffiliateSearchParams(parsed, originalName) {
 
   if (originalName) {
     paramsList.push({ name: originalName });
-    paramsList.push({ keyword: originalName });
   }
 
   var unique = [];


### PR DESCRIPTION
## Summary
- remove unsupported keyword parameter from affiliate search queries so valid results return

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d65f04ba488328a13c727adb593e06