### PR TITLE
Log parsed API data for affiliate partnership script

### DIFF
--- a/applyAffiliatePartnerships.gs
+++ b/applyAffiliatePartnerships.gs
@@ -448,7 +448,19 @@ function callApi(path, options) {
   Logger.log('API Response: %s status=%s body=%s', url, status, text);
 
   if (status >= 200 && status < 300) {
-    return text ? JSON.parse(text) : {};
+    var json;
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch (parseError) {
+        Logger.log('API Response Parse Error: %s error=%s', url, parseError);
+        throw parseError;
+      }
+    } else {
+      json = {};
+    }
+    Logger.log('API Response Parsed: %s data=%s', url, JSON.stringify(json));
+    return json;
   }
 
   var errorMessage = 'APIリクエストに失敗しました。HTTP ' + status;


### PR DESCRIPTION
## Summary
- add parsed API response logging to provide visibility into returned data
- include error logging for JSON parse failures when handling API responses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d660ed6cf883289a9c9f1f78b3830c